### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -16,7 +16,7 @@ language = "Rust"
 wit-version = "1.0.0"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && mv ./target/wasm32-wasip2/release/posthog.wasm ./posthog.wasm"
+command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && rm -f ./posthog.wasm && mv ./target/wasm32-wasip2/release/posthog.wasm ./posthog.wasm"
 output_path = "posthog.wasm"
 
 [component.settings.region]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink